### PR TITLE
Use rosidl_runtime_py instead of rqt_py_common where possible

### DIFF
--- a/src/rqt_publisher/publisher.py
+++ b/src/rqt_publisher/publisher.py
@@ -40,10 +40,13 @@ from python_qt_binding.QtCore import Slot, QSignalMapper, QTimer, qWarning
 
 from rclpy.exceptions import InvalidTopicNameException
 from rclpy.qos import QoSProfile
+
+from rosidl_runtime_py.utilities import get_message
+
 from rqt_gui_py.plugin import Plugin
-from .publisher_widget import PublisherWidget
-from rqt_py_common.message_helpers import get_message_class
 from rqt_py_common.topic_helpers import get_slot_type
+
+from .publisher_widget import PublisherWidget
 
 _list_types = [list, tuple, array.array]
 try:
@@ -128,7 +131,7 @@ class Publisher(Plugin):
         if publisher_info['message_instance'] is None:
             return
 
-        msg_module = get_message_class(publisher_info['type_name'])
+        msg_module = get_message(publisher_info['type_name'])
         if not msg_module:
             raise RuntimeError(
                 'The passed message type "{}" is invalid'.format(publisher_info['type_name']))
@@ -274,7 +277,7 @@ class Publisher(Plugin):
         base_type_str, array_size = self._extract_array_info(type_str)
 
         try:
-            base_message_type = get_message_class(base_type_str)
+            base_message_type = get_message(base_type_str)
         except LookupError as e:
             qWarning("Creating message type {} failed. Please check your spelling and that the "
                      "message package has been built\n{}".format(base_type_str, e))

--- a/src/rqt_publisher/publisher.py
+++ b/src/rqt_publisher/publisher.py
@@ -44,7 +44,6 @@ from rclpy.qos import QoSProfile
 from rosidl_runtime_py.utilities import get_message
 
 from rqt_gui_py.plugin import Plugin
-from rqt_py_common.topic_helpers import get_slot_type
 
 from .publisher_widget import PublisherWidget
 
@@ -214,52 +213,6 @@ class Publisher(Plugin):
                 publisher_info['timer'].start(int(1000.0 / publisher_info['rate']))
         # make sure the column value reflects the actual rate
         return '%.2f' % publisher_info['rate']
-
-    def _change_publisher_expression(self, publisher_info, topic_name, new_value):
-        expression = str(new_value)
-        if len(expression) == 0:
-            if topic_name in publisher_info['expressions']:
-                del publisher_info['expressions'][topic_name]
-                # qDebug(
-                #   'Publisher._change_publisher_expression(): removed expression'
-                #   'for: %s' % (topic_name))
-        else:
-            # Strip topic name from the full topic path
-            slot_path = topic_name.replace(publisher_info['topic_name'], '', 1)
-            slot_path, slot_array_index = self._extract_array_info(slot_path)
-
-            # Get the property type from the message class
-            slot_type, is_array = \
-                get_slot_type(publisher_info['message_instance'].__class__, slot_path)
-            if slot_array_index is not None:
-                is_array = False
-
-            if is_array:
-                slot_type = list
-            # strip possible trailing error message from expression
-            error_prefix = '# error'
-            error_prefix_pos = expression.find(error_prefix)
-            if error_prefix_pos >= 0:
-                expression = expression[:error_prefix_pos]
-            success, _ = self._evaluate_expression(expression, slot_type)
-            if success:
-                old_expression = publisher_info['expressions'].get(topic_name, None)
-                publisher_info['expressions'][topic_name] = expression
-                try:
-                    self._fill_message_slots(
-                        publisher_info['message_instance'], publisher_info['topic_name'],
-                        publisher_info['expressions'], publisher_info['counter'])
-
-                except Exception as e:
-                    if old_expression is not None:
-                        publisher_info['expressions'][topic_name] = old_expression
-                    else:
-                        del publisher_info['expressions'][topic_name]
-                    return '%s %s: %s' % (expression, error_prefix, e)
-                return expression
-            else:
-                return '%s %s evaluating as "%s"' % (
-                    expression, error_prefix, slot_type.__name__)
 
     def _extract_array_info(self, type_str):
         array_size = None

--- a/src/rqt_publisher/publisher_widget.py
+++ b/src/rqt_publisher/publisher_widget.py
@@ -43,10 +43,12 @@ from python_qt_binding.QtWidgets import QWidget
 from qt_gui.ros_package_helper import get_package_path
 from qt_gui_py_common.worker_thread import WorkerThread
 
-from .publisher_tree_widget import PublisherTreeWidget
-from rqt_py_common.extended_combo_box import ExtendedComboBox
-from rqt_py_common.message_helpers import get_message_class, get_all_message_types
+from rosidl_runtime_py import get_message_interfaces
+from rosidl_runtime_py.utilities import get_message
 
+from rqt_py_common.extended_combo_box import ExtendedComboBox
+
+from .publisher_tree_widget import PublisherTreeWidget
 
 # main class inherits from the ui window class
 class PublisherWidget(QWidget):
@@ -114,11 +116,11 @@ class PublisherWidget(QWidget):
     def _update_thread_run(self):
         # update type_combo_box
         message_type_names = []
-        message_types = get_all_message_types()
+        message_types = get_message_interfaces()
         for package, message_types in message_types.items():
             for message_type in message_types:
-                base_type_str = package + '/msg/' + message_type
-                message_class = get_message_class(base_type_str)
+                base_type_str = f'{package}/{message_type}'
+                message_class = get_message(base_type_str)
                 if message_class is not None:
                     message_type_names.append(base_type_str)
 


### PR DESCRIPTION
[First commit](https://github.com/ros-visualization/rqt_publisher/commit/cc9266516fbe7a7db4f0346f1834c6e701528670) does what the title say.
[The second](https://github.com/ros-visualization/rqt_publisher/commit/367049ecc4ce3cabed9d5ca452fb478a98a3ba21) removes dead code ....

I will create a `foxy-devel` branch for this, as `rosidl_runtime_py` didn't exist in `dashing` (thought the same methods were available in another place).