### PR TITLE
Drop numpy.float128 references

### DIFF
--- a/src/rqt_publisher/publisher.py
+++ b/src/rqt_publisher/publisher.py
@@ -59,7 +59,7 @@ try:
     import numpy
     _numeric_types += [
         numpy.int8, numpy.int16, numpy.int32, numpy.int64,
-        numpy.float16, numpy.float32, numpy.float64, numpy.float128,
+        numpy.float16, numpy.float32, numpy.float64
     ]
 except ImportError:
     pass


### PR DESCRIPTION
It is not used by rosidl_python, it is not supported on Windows.

Tested on Windows. CI up to `rqt_publisher`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14395)](http://ci.ros2.org/job/ci_linux/14395/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9169)](http://ci.ros2.org/job/ci_linux-aarch64/9169/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12070)](http://ci.ros2.org/job/ci_osx/12070/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14494)](http://ci.ros2.org/job/ci_windows/14494/)
