### PR TITLE
Handle arrays that contain non primitives

### DIFF
--- a/src/rqt_publisher/publisher.py
+++ b/src/rqt_publisher/publisher.py
@@ -227,6 +227,14 @@ class Publisher(Plugin):
             # Strip topic name from the full topic path
             slot_path = topic_name.replace(publisher_info['topic_name'], '', 1)
             slot_path, slot_array_index = self._extract_array_info(slot_path)
+            
+            # Remove all "indexes" from slot_path, so get_slot_type works
+            opening_bracket = slot_path.find('[')
+            closing_bracket = slot_path.find(']')
+            while opening_bracket != -1 and closing_bracket != -1:
+                slot_path = slot_path[:opening_bracket] + slot_path[closing_bracket+1:]
+                opening_bracket = slot_path.find('[')
+                closing_bracket = slot_path.find(']')
 
             # Get the property type from the message class
             slot_type, is_array = \
@@ -263,8 +271,8 @@ class Publisher(Plugin):
 
     def _extract_array_info(self, type_str):
         array_size = None
-        if '[' in type_str and type_str[-1] == ']':
-            type_str, array_size_str = type_str.split('[', 1)
+        if type_str[-1] == ']':
+            type_str, array_size_str = type_str.rsplit('[', 1)
             array_size_str = array_size_str[:-1]
             if len(array_size_str) > 0:
                 array_size = int(array_size_str)


### PR DESCRIPTION
If we have an array of non primitive types, the slot_path would be something like "/leds[10]]/r".
This is an unexpected input to `get_slot_type`, it should be "/leds/r".
A [test in rqt_py_common](https://github.com/ros-visualization/rqt/blob/943797aed6f86cbc0ec8619592ff2f17337e605d/rqt_py_common/test/test_rqt_topic_helpers.py#L46) backs this.

~~627510e is cherry-picked from PR #28, which should be merged first.
5c2a603 are the additions for this PR, and handles array that contains non primitives.~~

Relates to Issue #23.