### PR TITLE
Change slot_type verification strategy

### DIFF
--- a/src/rqt_publisher/publisher.py
+++ b/src/rqt_publisher/publisher.py
@@ -230,18 +230,19 @@ class Publisher(Plugin):
             slot_type = None
 
             # strip possible trailing error message from expression
-            error_prefix = ' # error'
-            error_prefix_pos = user_expression.find(error_prefix)
-            if error_prefix_pos >= 0:
-                user_expression = user_expression[:error_prefix_pos]
+            contains_error = re.match("(.*)\s*# error.*", user_expression)
+            if contains_error:
+                user_expression = contains_error.group(1)
 
             computed_expression = str(user_expression)
-            # reduce indexed topic_names, if necessary
-            topic_name_reduction = re.match("(.*)\[[0-9]*\]$", topic_name)
-            if topic_name_reduction:
-                topic_name = topic_name_reduction.group(1)
+            # expression can contain topics with indexes, i.e. /chatter[0]
+            # remove index to match message_instance, i.e. /chatter
+            topic_name_includes_index = re.match("(.*)\[[0-9]*\]$", topic_name)
+            if topic_name_includes_index:
+                topic_name = topic_name_includes_index.group(1)
 
-            # sequences
+            # static sequences change one item at a time, impossible to validate
+            # handle as entire sequence, enables validation
             if slot_array_index is not None:
                 # remove first '/'
                 slot_array = \
@@ -255,11 +256,11 @@ class Publisher(Plugin):
                 try:
                     slot_array[slot_array_index] = computed_expression
                 except Exception as e:
-                    return '%s %s: %s' % (user_expression, error_prefix, e)
+                    return '%s # error: %s' % (user_expression, e)
                 # expression is now full sequence
                 computed_expression = slot_array
 
-            # Get the property type
+            # determine the property type, supplemental wrapper for get_slot_type()
             slot_type = \
                 self._resolve_slot_type(computed_expression, slot_type, slot_path, publisher_info['message_instance'].__class__)
             success, _ = self._evaluate_expression(computed_expression, slot_type)
@@ -275,11 +276,11 @@ class Publisher(Plugin):
                         publisher_info['expressions'][topic_name] = old_expression
                     else:
                         del publisher_info['expressions'][topic_name]
-                    return '%s %s: %s' % (user_expression, error_prefix, e)
+                    return '%s # error: %s' % (user_expression, e)
                 return user_expression
             else:
-                return '%s %s evaluating as "%s"' % (
-                    user_expression, error_prefix, slot_type.__name__)
+                return '%s # error evaluating as "%s"' % (
+                    user_expression, slot_type.__name__)
 
     def _extract_array_info(self, type_str):
         array_size = None
@@ -302,20 +303,23 @@ class Publisher(Plugin):
 
     def _resolve_slot_type(self, expression, slot_type, slot_path, message_class):
         if slot_type is None:
-            # array.array
+            # check for types that get_slot_type doesn't handle well
+            # check for array.array type
             is_array_array = re.search("^array\(\'.\', (\[.*\])\)", expression)
             if is_array_array:
                 return array.array
-                # return is_array_array.group(1), array.array
-            # list
+
+            # check for list type
             is_list = re.match("^\[.*\]\s*$", expression)
             if is_list:
                 return list
-            # string
+
+            # check for string type
             is_string = re.match("^\'.*\'\s*$", expression)
             if is_string:
                 return str
 
+            # at this point, get_slot_type can determine the type
             slot_type, _ = \
                 get_slot_type(message_class, slot_path)
 


### PR DESCRIPTION
We ran into an issue where `get_slot_type` kept returning `None` on primitive types and strings in several configurations (`sequence<float>`, `string<25>`, `sequence<string>`, etc.). Also saw that static arrays of items were not being validated in the gui, i.e. a `sequence<string<25>, 5>` could have strings with 26+ characters without indicating an error.

In an attempt to minimize the `get_slot_type` issue, I used regex matching to define the type based on the user's input. I also added `array` functionality to the `_eval_locals`.

When evaluating a static array, instead of inspecting the individual item, I remove the index in the `topic_name`, copy the message instance's version of the array, insert the expression, and then set the expression to the array. This allows the array to be validated.