### PR TITLE
Minor cleanups in rqt_publisher for ROS 2

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,9 +13,12 @@
 
   <author>Dorian Scholz</author>
 
+  <exec_depend>ament_index_python</exec_depend>
   <exec_depend version_gte="0.2.19">python_qt_binding</exec_depend>
-  <exec_depend>python3-catkin-pkg-modules</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
   <exec_depend>qt_gui_py_common</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>rosidl_runtime_py</exec_depend>
   <exec_depend>rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>
   <exec_depend>rqt_py_common</exec_depend>

--- a/src/rqt_publisher/publisher.py
+++ b/src/rqt_publisher/publisher.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright (c) 2011, Dorian Scholz, TU Darmstadt
 # All rights reserved.
 #
@@ -30,7 +28,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import division
 import array
 import math
 import random

--- a/src/rqt_publisher/publisher.py
+++ b/src/rqt_publisher/publisher.py
@@ -161,9 +161,6 @@ class Publisher(Plugin):
 
     def _change_publisher_topic(self, publisher_info, topic_name, new_value):
         publisher_info['enabled'] = (new_value and new_value.lower() in ['1', 'true', 'yes'])
-        # qDebug(
-        #   'Publisher._change_publisher_enabled(): %s enabled: %s' %
-        #   (publisher_info['topic_name'], publisher_info['enabled']))
         if publisher_info['enabled'] and publisher_info['rate'] > 0:
             publisher_info['timer'].start(int(1000.0 / publisher_info['rate']))
         else:
@@ -203,9 +200,6 @@ class Publisher(Plugin):
                      (new_value))
         else:
             publisher_info['rate'] = rate
-            # qDebug(
-            #   'Publisher._change_publisher_rate(): %s rate changed: %fHz' %
-            #   (publisher_info['topic_name'], publisher_info['rate']))
             publisher_info['timer'].stop()
             if publisher_info['enabled'] and publisher_info['rate'] > 0:
                 publisher_info['timer'].start(int(1000.0 / publisher_info['rate']))

--- a/src/rqt_publisher/publisher_tree_model.py
+++ b/src/rqt_publisher/publisher_tree_model.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright (c) 2011, Dorian Scholz, TU Darmstadt
 # All rights reserved.
 #
@@ -29,6 +27,7 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+
 import threading
 
 from python_qt_binding.QtCore import Qt, Signal

--- a/src/rqt_publisher/publisher_tree_model.py
+++ b/src/rqt_publisher/publisher_tree_model.py
@@ -64,7 +64,6 @@ class PublisherTreeModel(MessageTreeModel):
 
     def handle_item_changed(self, item):
         if not self._item_change_lock.acquire(False):
-            # qDebug('PublisherTreeModel.handle_item_changed(): could not acquire lock')
             return
         # lock has been acquired
         topic_name = item._path
@@ -73,8 +72,6 @@ class PublisherTreeModel(MessageTreeModel):
             new_value = str(item.checkState() == Qt.Checked)
         else:
             new_value = item.text().strip()
-        # print 'PublisherTreeModel.handle_item_changed(): %s, %s, %s' %
-        # (topic_name, column_name, new_value)
 
         self.item_value_changed.emit(
             item._user_data['publisher_id'], topic_name, column_name, new_value, item.setText)

--- a/src/rqt_publisher/publisher_tree_widget.py
+++ b/src/rqt_publisher/publisher_tree_widget.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright (c) 2011, Dorian Scholz, TU Darmstadt
 # All rights reserved.
 #

--- a/src/rqt_publisher/publisher_widget.py
+++ b/src/rqt_publisher/publisher_widget.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright (c) 2011, Dorian Scholz, TU Darmstadt
 # All rights reserved.
 #
@@ -30,7 +28,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import division
 import os
 
 from ament_index_python import get_resource, has_resource


### PR DESCRIPTION
There are 3 commits in here:

1. Remove old Python 2 compatibility code; we don't need it on the ROS 2 branch.
2. Remove some commented out debugging code.
3. Cleanup dependencies to reflect what is actually needed in this package.